### PR TITLE
Fix docker on windows (.sh files should have LF line endings)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
See #3 

Figured it out; The `initdb.sh` script was checked out with `CRLF` line endings (Windows default); but bash is pretty particular about it's line endings and requires `LF`. So I added `.gitattributes` to ensure Git checks out `*.sh` files with UNIX line endings (`LF`).

The unittests pass now, so I can start work on creating a MS SQL Server variant.