### PR TITLE
SQL Server implementation

### DIFF
--- a/KafkaFlow.Contrib.sln
+++ b/KafkaFlow.Contrib.sln
@@ -17,9 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.Outbox.Po
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.ProcessManagers.Postgres", "src\Contrib.KafkaFlow.ProcessManagers.Postgres\Contrib.KafkaFlow.ProcessManagers.Postgres.csproj", "{6A9E74CC-3E65-4422-8E3E-862C3A999B72}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.Outbox.SqlServer", "src\Contrib.KafkaFlow.Outbox.SqlServer\Contrib.KafkaFlow.Outbox.SqlServer.csproj", "{A4CBB313-9DCC-441E-BB44-1473CDF7A986}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.Outbox.SqlServer", "src\Contrib.KafkaFlow.Outbox.SqlServer\Contrib.KafkaFlow.Outbox.SqlServer.csproj", "{A4CBB313-9DCC-441E-BB44-1473CDF7A986}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.ProcessManagers.SqlServer", "src\Contrib.KafkaFlow.ProcessManagers.SqlServer\Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj", "{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.ProcessManagers.SqlServer", "src\Contrib.KafkaFlow.ProcessManagers.SqlServer\Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj", "{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.SqlServer", "src\Contrib.KafkaFlow.SqlServer\Contrib.KafkaFlow.SqlServer.csproj", "{6839FA17-DF28-418B-AB5A-2249D44F4CA3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +57,10 @@ Global
 		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6839FA17-DF28-418B-AB5A-2249D44F4CA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6839FA17-DF28-418B-AB5A-2249D44F4CA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6839FA17-DF28-418B-AB5A-2249D44F4CA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6839FA17-DF28-418B-AB5A-2249D44F4CA3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,6 +73,7 @@ Global
 		{6A9E74CC-3E65-4422-8E3E-862C3A999B72} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
 		{A4CBB313-9DCC-441E-BB44-1473CDF7A986} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
 		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
+		{6839FA17-DF28-418B-AB5A-2249D44F4CA3} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {66EE15D8-69C4-4AFB-9EB8-6020B2D8C01A}

--- a/KafkaFlow.Contrib.sln
+++ b/KafkaFlow.Contrib.sln
@@ -1,18 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.ProcessManagers", "src\Contrib.KafkaFlow.ProcessManagers\Contrib.KafkaFlow.ProcessManagers.csproj", "{1DD0DA5D-63CD-4FC3-972E-CD376139810A}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.ProcessManagers", "src\Contrib.KafkaFlow.ProcessManagers\Contrib.KafkaFlow.ProcessManagers.csproj", "{1DD0DA5D-63CD-4FC3-972E-CD376139810A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{CE99781E-E88C-404C-B9AD-D7F713265F31}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A5E2EC13-2E8B-4EB3-8C0F-D252A04B42F4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaFlow.ProcessManagers.IntegrationTests", "tests\KafkaFlow.ProcessManagers.IntegrationTests\KafkaFlow.ProcessManagers.IntegrationTests.csproj", "{F3DB8E66-BEA2-494F-B908-57C83BDF1501}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaFlow.ProcessManagers.IntegrationTests", "tests\KafkaFlow.ProcessManagers.IntegrationTests\KafkaFlow.ProcessManagers.IntegrationTests.csproj", "{F3DB8E66-BEA2-494F-B908-57C83BDF1501}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.Outbox", "src\Contrib.KafkaFlow.Outbox\Contrib.KafkaFlow.Outbox.csproj", "{39CF3703-98C2-4EE5-872B-AEFE85EEAC9A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.Outbox", "src\Contrib.KafkaFlow.Outbox\Contrib.KafkaFlow.Outbox.csproj", "{39CF3703-98C2-4EE5-872B-AEFE85EEAC9A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.Outbox.Postgres", "src\Contrib.KafkaFlow.Outbox.Postgres\Contrib.KafkaFlow.Outbox.Postgres.csproj", "{95A1F8B4-98B2-42F2-8CF1-0067F3D6B125}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.Outbox.Postgres", "src\Contrib.KafkaFlow.Outbox.Postgres\Contrib.KafkaFlow.Outbox.Postgres.csproj", "{95A1F8B4-98B2-42F2-8CF1-0067F3D6B125}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.ProcessManagers.Postgres", "src\Contrib.KafkaFlow.ProcessManagers.Postgres\Contrib.KafkaFlow.ProcessManagers.Postgres.csproj", "{6A9E74CC-3E65-4422-8E3E-862C3A999B72}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contrib.KafkaFlow.ProcessManagers.Postgres", "src\Contrib.KafkaFlow.ProcessManagers.Postgres\Contrib.KafkaFlow.ProcessManagers.Postgres.csproj", "{6A9E74CC-3E65-4422-8E3E-862C3A999B72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.Outbox.SqlServer", "src\Contrib.KafkaFlow.Outbox.SqlServer\Contrib.KafkaFlow.Outbox.SqlServer.csproj", "{A4CBB313-9DCC-441E-BB44-1473CDF7A986}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contrib.KafkaFlow.ProcessManagers.SqlServer", "src\Contrib.KafkaFlow.ProcessManagers.SqlServer\Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj", "{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +47,17 @@ Global
 		{6A9E74CC-3E65-4422-8E3E-862C3A999B72}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A9E74CC-3E65-4422-8E3E-862C3A999B72}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A9E74CC-3E65-4422-8E3E-862C3A999B72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4CBB313-9DCC-441E-BB44-1473CDF7A986}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4CBB313-9DCC-441E-BB44-1473CDF7A986}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4CBB313-9DCC-441E-BB44-1473CDF7A986}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4CBB313-9DCC-441E-BB44-1473CDF7A986}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1DD0DA5D-63CD-4FC3-972E-CD376139810A} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
@@ -47,5 +65,10 @@ Global
 		{39CF3703-98C2-4EE5-872B-AEFE85EEAC9A} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
 		{95A1F8B4-98B2-42F2-8CF1-0067F3D6B125} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
 		{6A9E74CC-3E65-4422-8E3E-862C3A999B72} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
+		{A4CBB313-9DCC-441E-BB44-1473CDF7A986} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
+		{3F0C0AD0-CFD8-4722-BF3B-6259D0878680} = {CE99781E-E88C-404C-B9AD-D7F713265F31}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {66EE15D8-69C4-4AFB-9EB8-6020B2D8C01A}
 	EndGlobalSection
 EndGlobal

--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ ecosystem.
   The following backends are implemented:
 
   - [Contrib.KafkaFlow.Outbox.Postgres](./src/Contrib.KafkaFlow.Outbox.Postgres) - Postgres SQL backend
+  - [Contrib.KafkaFlow.Outbox.SqlServer](./src/Contrib.KafkaFlow.Outbox.SqlServer) - SQL Server backend
 
 
 - [Contrib.KafkaFlow.ProcessManagers](./src/Contrib.KafkaFlow.ProcessManagers/Readme.md)
@@ -22,6 +23,8 @@ ecosystem.
 
   - [Contrib.KafkaFlow.ProcessManagers.Postgres](./src/Contrib.KafkaFlow.ProcessManagers.Postgres) -
     Postgres SQL backend for storing process' state
+  - [Contrib.KafkaFlow.ProcessManagers.SqlServer](./src/Contrib.KafkaFlow.ProcessManagers.SqlServer) -
+    SQL Server backend for storing process' state
 
 ## Usage example
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
     ports:
         - "1433:1433/tcp"
     restart: unless-stopped
+    command: ["/bin/bash", "-c", "/docker-entrypoint-initdb.d/initdb.sh"]
     volumes:
       - "./local-env/mssql:/docker-entrypoint-initdb.d"
       - "./src/Contrib.KafkaFlow.Outbox.SqlServer/schema:/docker-entrypoint-initdb.d/0001.outbox"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - KAFKA_SCHEMAREGISTRY_ENABLED=TRUE
       - KAFKA_SCHEMAREGISTRY_URLS=http://kafka:8081
 
-  db:
+  postgres:
     image: public.ecr.aws/docker/library/postgres:14.7-alpine
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,3 +61,22 @@ services:
       - "./local-env/postgres:/docker-entrypoint-initdb.d"
       - "./src/Contrib.KafkaFlow.Outbox.Postgres/schema:/docker-entrypoint-initdb.d/0001.outbox"
       - "./src/Contrib.KafkaFlow.ProcessManagers.Postgres/schema:/docker-entrypoint-initdb.d/0002.processes"
+
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "4YiUmU2YJ8$6eqbSXF8765Ck3"
+      MSSQL_PID: Developer
+    healthcheck:
+      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$${MSSQL_SA_PASSWORD}" -Q "SELECT 1" || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+        - "1433:1433/tcp"
+    restart: unless-stopped
+    volumes:
+      - "./local-env/mssql:/docker-entrypoint-initdb.d"
+      - "./src/Contrib.KafkaFlow.Outbox.SqlServer/schema:/docker-entrypoint-initdb.d/0001.outbox"
+      - "./src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema:/docker-entrypoint-initdb.d/0002.processes"

--- a/local-env/mssql/initdb.sh
+++ b/local-env/mssql/initdb.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Start SQL Server
+/opt/mssql/bin/sqlservr &
+
+# Wait for SQL to start
 TRIES=60
 DBSTATUS=1
 ERRCODE=1
@@ -14,6 +18,7 @@ while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt $TRIES ]]; do
 	fi
 done
 
+sleep 5s
 if [ $DBSTATUS -ne 0 ]; then 
 	echo "SQL Server took more than $TRIES seconds to start up or one or more databases are not in an ONLINE state"
 	exit 1
@@ -38,3 +43,6 @@ find /docker-entrypoint-initdb.d -mindepth 2 -type f | sort | while read f; do
   esac
   echo
 done
+
+echo "SQL Server is running"
+sleep infinity

--- a/local-env/mssql/initdb.sh
+++ b/local-env/mssql/initdb.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+TRIES=60
+DBSTATUS=1
+ERRCODE=1
+i=0
+
+echo "Waiting for SQL Server to start"
+while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt $TRIES ]]; do
+	i=$((i+1))
+	DBSTATUS=$(/opt/mssql-tools/bin/sqlcmd -h -1 -t 1 -U sa -P $MSSQL_SA_PASSWORD -Q "SET NOCOUNT ON; Select COALESCE(SUM(state), 0) from sys.databases") || DBSTATUS=1
+	if [ $DBSTATUS -ne 0 ]; then 
+        sleep 1s
+	fi
+done
+
+if [ $DBSTATUS -ne 0 ]; then 
+	echo "SQL Server took more than $TRIES seconds to start up or one or more databases are not in an ONLINE state"
+	exit 1
+fi
+
+mssql=( /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -d master -i )
+
+find /docker-entrypoint-initdb.d -mindepth 2 -type f | sort | while read f; do
+  case "$f" in
+    *.sh)
+      if [ -x "$f" ]; then
+        echo "$0: running $f"
+        "$f"
+      else
+        echo "$0: sourcing $f"
+        . "$f"
+      fi
+      ;;
+    *.sql)    echo "$0: running $f"; "${mssql[@]}" "$f"; echo ;;
+    *.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mssql[@]}"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done

--- a/src/Contrib.KafkaFlow.Outbox.Postgres/Contrib.KafkaFlow.Outbox.Postgres.csproj
+++ b/src/Contrib.KafkaFlow.Outbox.Postgres/Contrib.KafkaFlow.Outbox.Postgres.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.1.28" />
+      <PackageReference Include="Dapper" Version="2.1.35" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/ConfigurationBuilderExtensions.cs
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,10 @@
+using KafkaFlow;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KafkaFlow.Outbox.SqlServer;
+
+public static class ConfigurationBuilderExtensions
+{
+    public static IServiceCollection AddSqlServerOutboxBackend(this IServiceCollection services) =>
+        services.AddSingleton<IOutboxBackend, SqlServerOutboxBackend>();
+}

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/ConfigurationBuilderExtensions.cs
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/ConfigurationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using KafkaFlow;
+using KafkaFlow.SqlServer;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace KafkaFlow.Outbox.SqlServer;
@@ -7,4 +8,10 @@ public static class ConfigurationBuilderExtensions
 {
     public static IServiceCollection AddSqlServerOutboxBackend(this IServiceCollection services) =>
         services.AddSingleton<IOutboxBackend, SqlServerOutboxBackend>();
+
+    public static IServiceCollection AddSqlServerOutboxBackend(this IServiceCollection services, string connectionString)
+    {
+        services.ConfigureSqlServerBackend(options => options.ConnectionString = connectionString);
+        return AddSqlServerOutboxBackend(services);
+    }
 }

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/Contrib.KafkaFlow.Outbox.SqlServer.csproj
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/Contrib.KafkaFlow.Outbox.SqlServer.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Contrib.KafkaFlow.Outbox\Contrib.KafkaFlow.Outbox.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>  
+
+</Project>

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/Contrib.KafkaFlow.Outbox.SqlServer.csproj
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/Contrib.KafkaFlow.Outbox.SqlServer.csproj
@@ -4,9 +4,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Contrib.KafkaFlow.SqlServer\Contrib.KafkaFlow.SqlServer.csproj" />
     <ProjectReference Include="..\Contrib.KafkaFlow.Outbox\Contrib.KafkaFlow.Outbox.csproj" />
   </ItemGroup>
 
@@ -17,6 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-  </ItemGroup>  
+  </ItemGroup>
 
 </Project>

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/SqlServerOutboxBackend.cs
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/SqlServerOutboxBackend.cs
@@ -9,9 +9,9 @@ namespace KafkaFlow.Outbox.SqlServer;
 
 public class SqlServerOutboxBackend : IOutboxBackend
 {
-    private readonly SqlServerOptions _options;
+    private readonly SqlServerBackendOptions _options;
 
-    public SqlServerOutboxBackend(IOptions<SqlServerOptions> options)
+    public SqlServerOutboxBackend(IOptions<SqlServerBackendOptions> options)
         => _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
     public async ValueTask Store(TopicPartition topicPartition, Message<byte[], byte[]> message, CancellationToken token = default)

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/SqlServerOutboxBackend.cs
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/SqlServerOutboxBackend.cs
@@ -1,0 +1,95 @@
+﻿using Confluent.Kafka;
+using Dapper;
+using KafkaFlow.SqlServer;
+using Microsoft.Extensions.Options;
+using System.Data.SqlClient;
+using System.Text.Json;
+
+namespace KafkaFlow.Outbox.SqlServer;
+
+public class SqlServerOutboxBackend : IOutboxBackend
+{
+    private readonly SqlServerOptions _options;
+
+    public SqlServerOutboxBackend(IOptions<SqlServerOptions> options)
+        => _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+
+    public async ValueTask Store(TopicPartition topicPartition, Message<byte[], byte[]> message, CancellationToken token = default)
+    {
+        var sql = """
+            INSERT INTO [outbox] ([topic_name], [partition], [message_key], [message_headers], [message_body])
+            VALUES (@topic_name, @partition, @message_key, @message_headers, @message_body);
+            """;
+
+        using var conn = new SqlConnection(_options.ConnectionString);
+
+        var rawHeaders =
+            message.Headers == null
+            ? null
+            : JsonSerializer.Serialize(message.Headers.ToDictionary(x => x.Key, x => x.GetValueBytes()));
+
+        var res = await conn.ExecuteAsync(sql, new
+        {
+            topic_name = topicPartition.Topic,
+            partition = topicPartition.Partition.IsSpecial ? null : (int?)topicPartition.Partition.Value,
+            message_key = message.Key,
+            message_headers = rawHeaders,
+            message_body = message.Value
+        }).ConfigureAwait(false);
+
+    }
+
+    public async ValueTask<OutboxRecord[]> Read(int batchSize, CancellationToken token = default)
+    {
+        var sql = """
+            DELETE FROM [outbox]
+            OUTPUT DELETED.*
+            WHERE
+                [sequence_id] IN (
+                    SELECT TOP (@batch_size) [sequence_id] FROM [outbox]
+                    ORDER BY [sequence_id]
+                );
+            """;
+        using var conn = new SqlConnection(_options.ConnectionString);
+        var result = await conn.QueryAsync<OutboxTableRow>(sql, new { batch_size = batchSize });
+
+        return result?.Select(ToOutboxRecord).ToArray() ?? Array.Empty<OutboxRecord>();
+    }
+
+    private static OutboxRecord ToOutboxRecord(OutboxTableRow row)
+    {
+        var partition = row.partition.HasValue ? new Partition(row.partition.Value) : Partition.Any;
+        var topicPartition = new TopicPartition(row.topic_name, partition);
+
+        var storedHeaders =
+            row.message_headers == null
+                ? null
+                : JsonSerializer.Deserialize<Dictionary<string, byte[]>>(row.message_headers);
+
+        var headers =
+            storedHeaders?.Aggregate(new Headers(), (h, x) =>
+            {
+                h.Add(x.Key, x.Value);
+                return h;
+            });
+
+        var msg = new Message<byte[], byte[]>
+        {
+            Key = row.message_key!,
+            Value = row.message_body!,
+            Headers = headers
+        };
+
+        return new OutboxRecord(topicPartition, msg);
+    }
+}
+
+internal sealed class OutboxTableRow
+{
+    public long sequence_id { get; set; }
+    public string topic_name { get; set; } = null!;
+    public int? partition { get; set; }
+    public byte[]? message_key { get; set; }
+    public string? message_headers { get; set; }
+    public byte[]? message_body { get; set; }
+}

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/SqlServerOutboxBackend.cs
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/SqlServerOutboxBackend.cs
@@ -17,7 +17,7 @@ public class SqlServerOutboxBackend : IOutboxBackend
     public async ValueTask Store(TopicPartition topicPartition, Message<byte[], byte[]> message, CancellationToken token = default)
     {
         var sql = """
-            INSERT INTO [outbox] ([topic_name], [partition], [message_key], [message_headers], [message_body])
+            INSERT INTO [outbox].[outbox] ([topic_name], [partition], [message_key], [message_headers], [message_body])
             VALUES (@topic_name, @partition, @message_key, @message_headers, @message_body);
             """;
 
@@ -42,11 +42,11 @@ public class SqlServerOutboxBackend : IOutboxBackend
     public async ValueTask<OutboxRecord[]> Read(int batchSize, CancellationToken token = default)
     {
         var sql = """
-            DELETE FROM [outbox]
+            DELETE FROM [outbox].[outbox]
             OUTPUT DELETED.*
             WHERE
                 [sequence_id] IN (
-                    SELECT TOP (@batch_size) [sequence_id] FROM [outbox]
+                    SELECT TOP (@batch_size) [sequence_id] FROM [outbox].[outbox]
                     ORDER BY [sequence_id]
                 );
             """;

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0001.Shema.sql
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0001.Shema.sql
@@ -1,0 +1,5 @@
+IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'kafkaflowtest')
+BEGIN
+	CREATE DATABASE [kafkaflowtest]
+END
+GO

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0001.Shema.sql
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0001.Shema.sql
@@ -1,5 +1,5 @@
-IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'kafkaflowtest')
+IF NOT EXISTS(SELECT * FROM sys.schemas WHERE name = 'outbox')
 BEGIN
-	CREATE DATABASE [kafkaflowtest]
+	EXEC ('CREATE SCHEMA [outbox] AUTHORIZATION [dbo]')
 END
 GO

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0002.Table.sql
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0002.Table.sql
@@ -1,15 +1,18 @@
 /* Table */
-CREATE TABLE [kafkaflowtest].[dbo].[outbox](
-	[sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
-	[topic_name] [nvarchar](255) NOT NULL,
-	[partition] [int] NULL,
-	[message_key] [varbinary](max) NULL,
-	[message_headers] [nvarchar](max) NULL,
-	[message_body] [varbinary](max) NULL,
-	[date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
-    [rowversion] [int] NOT NULL DEFAULT(1),
-	CONSTRAINT [PK_outbox] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
-	CONSTRAINT [CK_headers_not_blank_or_empty] CHECK ((TRIM([message_headers])<>N'')),
-	CONSTRAINT [CK_topic_name_not_blank_or_empty] CHECK ((TRIM([topic_name])<>N''))
-)
+IF OBJECT_ID(N'[kafkaflowtest].[dbo].[outbox]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [kafkaflowtest].[dbo].[outbox](
+	    [sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
+	    [topic_name] [nvarchar](255) NOT NULL,
+	    [partition] [int] NULL,
+	    [message_key] [varbinary](max) NULL,
+	    [message_headers] [nvarchar](max) NULL,
+	    [message_body] [varbinary](max) NULL,
+	    [date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+        [rowversion] [int] NOT NULL DEFAULT(1),
+	    CONSTRAINT [PK_outbox] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
+	    CONSTRAINT [CK_headers_not_blank_or_empty] CHECK ((TRIM([message_headers])<>N'')),
+	    CONSTRAINT [CK_topic_name_not_blank_or_empty] CHECK ((TRIM([topic_name])<>N''))
+    )
+END
 GO

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0002.Table.sql
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0002.Table.sql
@@ -1,0 +1,15 @@
+/* Table */
+CREATE TABLE [kafkaflowtest].[dbo].[outbox](
+	[sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
+	[topic_name] [nvarchar](255) NOT NULL,
+	[partition] [int] NULL,
+	[message_key] [varbinary](max) NULL,
+	[message_headers] [nvarchar](max) NULL,
+	[message_body] [varbinary](max) NULL,
+	[date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+    [rowversion] [int] NOT NULL DEFAULT(1),
+	CONSTRAINT [PK_outbox] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
+	CONSTRAINT [CK_headers_not_blank_or_empty] CHECK ((TRIM([message_headers])<>N'')),
+	CONSTRAINT [CK_topic_name_not_blank_or_empty] CHECK ((TRIM([topic_name])<>N''))
+)
+GO

--- a/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0002.Table.sql
+++ b/src/Contrib.KafkaFlow.Outbox.SqlServer/schema/0002.Table.sql
@@ -1,7 +1,7 @@
 /* Table */
-IF OBJECT_ID(N'[kafkaflowtest].[dbo].[outbox]', N'U') IS NULL
+IF OBJECT_ID(N'[outbox].[outbox]', N'U') IS NULL
 BEGIN
-    CREATE TABLE [kafkaflowtest].[dbo].[outbox](
+    CREATE TABLE [outbox].[outbox](
 	    [sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
 	    [topic_name] [nvarchar](255) NOT NULL,
 	    [partition] [int] NULL,

--- a/src/Contrib.KafkaFlow.Outbox/Contrib.KafkaFlow.Outbox.csproj
+++ b/src/Contrib.KafkaFlow.Outbox/Contrib.KafkaFlow.Outbox.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="KafkaFlow.Abstractions" Version="3.0.3" />
-      <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.3" />
+      <PackageReference Include="KafkaFlow.Abstractions" Version="3.0.7" />
+      <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.7" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Contrib.KafkaFlow.ProcessManagers.Postgres/Contrib.KafkaFlow.ProcessManagers.Postgres.csproj
+++ b/src/Contrib.KafkaFlow.ProcessManagers.Postgres/Contrib.KafkaFlow.ProcessManagers.Postgres.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.1.28" />
+      <PackageReference Include="Dapper" Version="2.1.35" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/ConfigurationBuilderExtensions.cs
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,10 @@
+using KafkaFlow;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KafkaFlow.ProcessManagers.SqlServer;
+
+public static class ConfigurationBuilderExtensions
+{
+    public static IServiceCollection AddSqlServerProcessManagerState(this IServiceCollection services) =>
+        services.AddSingleton<IProcessStateStore, SqlServerProcessManagersStore>();
+}

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/ConfigurationBuilderExtensions.cs
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/ConfigurationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using KafkaFlow;
+using KafkaFlow.SqlServer;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace KafkaFlow.ProcessManagers.SqlServer;
@@ -7,4 +8,11 @@ public static class ConfigurationBuilderExtensions
 {
     public static IServiceCollection AddSqlServerProcessManagerState(this IServiceCollection services) =>
         services.AddSingleton<IProcessStateStore, SqlServerProcessManagersStore>();
+
+
+    public static IServiceCollection AddSqlServerProcessManagerState(this IServiceCollection services, string connectionString)
+    {
+        services.ConfigureSqlServerBackend(options => options.ConnectionString = connectionString);
+        return AddSqlServerProcessManagerState(services);
+    }
 }

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Contrib.KafkaFlow.ProcessManagers\Contrib.KafkaFlow.ProcessManagers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+  </ItemGroup>
+
+</Project>

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj
@@ -4,9 +4,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Contrib.KafkaFlow.SqlServer\Contrib.KafkaFlow.SqlServer.csproj" />
     <ProjectReference Include="..\Contrib.KafkaFlow.ProcessManagers\Contrib.KafkaFlow.ProcessManagers.csproj" />
   </ItemGroup>
 

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
@@ -8,9 +8,9 @@ namespace KafkaFlow.ProcessManagers.SqlServer;
 
 public sealed class SqlServerProcessManagersStore : IProcessStateStore
 {
-    private readonly SqlServerOptions _options;
+    private readonly SqlServerBackendOptions _options;
 
-    public SqlServerProcessManagersStore(IOptions<SqlServerOptions> options)
+    public SqlServerProcessManagersStore(IOptions<SqlServerBackendOptions> options)
         => _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
     public async ValueTask Persist(Type processType, Guid processId, VersionedState state)

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
@@ -19,7 +19,7 @@ public sealed class SqlServerProcessManagersStore : IProcessStateStore
             MERGE INTO [processes] as [target]
             USING (VALUES (@process_type, @process_id,@process_state)) AS [source] ([process_type], [process_id], [process_state])
             ON [target].[process_type] = @process_type AND [target].[process_id] = @process_id
-            WHEN MATCHED THEN
+            WHEN MATCHED AND [target].[rowversion] = @Version THEN
              UPDATE SET
                 [process_state] = @process_state,
                 [date_updated_utc] = SYSUTCDATETIME(),

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
@@ -1,0 +1,101 @@
+﻿using Dapper;
+using KafkaFlow.SqlServer;
+using Microsoft.Extensions.Options;
+using System.Data.SqlClient;
+using System.Text.Json;
+
+namespace KafkaFlow.ProcessManagers.SqlServer;
+
+public sealed class SqlServerProcessManagersStore : IProcessStateStore
+{
+    private readonly SqlServerOptions _options;
+
+    public SqlServerProcessManagersStore(IOptions<SqlServerOptions> options)
+        => _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+
+    public async ValueTask Persist(Type processType, Guid processId, VersionedState state)
+    {
+        var sql = """
+            MERGE INTO [processes] as [target]
+            USING (VALUES (@process_type, @process_id,@process_state)) AS [source] ([process_type], [process_id], [process_state])
+            ON [target].[process_type] = @process_type AND [target].[process_id] = @process_id
+            WHEN MATCHED THEN
+             UPDATE SET
+                [process_state] = @process_state,
+                [date_updated_utc] = SYSUTCDATETIME(),
+                [rowversion] = [target].[rowversion] + 1
+            WHEN NOT MATCHED THEN
+             INSERT ([process_type], [process_id], [process_state])
+             VALUES (@process_type, @process_id,@process_state);
+            """;
+
+        using var conn = new SqlConnection(_options.ConnectionString);
+        var result = await conn.ExecuteAsync(sql, new
+        {
+            process_type = processType.FullName,
+            process_id = processId,
+            process_state = JsonSerializer.Serialize(state.State),
+            version = state.Version
+        });
+
+        if (result == 0)
+        {
+            throw new OptimisticConcurrencyException(processType, processId,
+                $"Concurrency error when persisting state {processType.FullName}");
+        }
+    }
+
+    public async ValueTask<VersionedState> Load(Type processType, Guid processId)
+    {
+        var sql = """
+            SELECT [process_state], [rowversion] as [version]
+            FROM [processes]
+            WHERE [process_type] = @process_type AND [process_id] = @process_id;
+            """;
+
+        using var conn = new SqlConnection(_options.ConnectionString);
+        var result = await conn.QueryAsync<ProcessStateRow>(sql, new
+        {
+            process_type = processType.FullName,
+            process_id = processId
+        });
+
+        var firstResult = result?.FirstOrDefault();
+
+        if (firstResult == null)
+        {
+            return VersionedState.Zero;
+        }
+
+        var decoded = JsonSerializer.Deserialize(firstResult.process_state, processType);
+        return new VersionedState(firstResult.version, decoded);
+    }
+
+    public async ValueTask Delete(Type processType, Guid processId, int version)
+    {
+        var sql = """
+            DELETE FROM [processes]
+            WHERE [process_type] = @process_type AND [process_id] = @process_id and [rowversion] = @version;
+            """;
+
+        using var conn = new SqlConnection(_options.ConnectionString);
+        var result = await conn.ExecuteAsync(sql, new
+        {
+            process_type = processType.FullName,
+            process_id = processId,
+            version
+        });
+
+        if (result == 0)
+        {
+            throw new OptimisticConcurrencyException(processType, processId,
+                $"Concurrency error when persisting state {processType.FullName}");
+        }
+    }
+
+    private sealed class ProcessStateRow
+    {
+        public required string process_state { get; set; }
+        public required int version { get; set; }
+    }
+}

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/SqlServerProcessManagersStore.cs
@@ -16,7 +16,7 @@ public sealed class SqlServerProcessManagersStore : IProcessStateStore
     public async ValueTask Persist(Type processType, Guid processId, VersionedState state)
     {
         var sql = """
-            MERGE INTO [processes] as [target]
+            MERGE INTO [process_managers].[processes] as [target]
             USING (VALUES (@process_type, @process_id,@process_state)) AS [source] ([process_type], [process_id], [process_state])
             ON [target].[process_type] = @process_type AND [target].[process_id] = @process_id
             WHEN MATCHED AND [target].[rowversion] = @Version THEN
@@ -49,7 +49,7 @@ public sealed class SqlServerProcessManagersStore : IProcessStateStore
     {
         var sql = """
             SELECT [process_state], [rowversion] as [version]
-            FROM [processes]
+            FROM [process_managers].[processes]
             WHERE [process_type] = @process_type AND [process_id] = @process_id;
             """;
 
@@ -74,7 +74,7 @@ public sealed class SqlServerProcessManagersStore : IProcessStateStore
     public async ValueTask Delete(Type processType, Guid processId, int version)
     {
         var sql = """
-            DELETE FROM [processes]
+            DELETE FROM [process_managers].[processes]
             WHERE [process_type] = @process_type AND [process_id] = @process_id and [rowversion] = @version;
             """;
 

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0001.Schema.sql
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0001.Schema.sql
@@ -1,0 +1,5 @@
+IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'kafkaflowtest')
+BEGIN
+	CREATE DATABASE [kafkaflowtest]
+END
+GO

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0001.Schema.sql
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0001.Schema.sql
@@ -1,5 +1,5 @@
-IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'kafkaflowtest')
+IF NOT EXISTS(SELECT * FROM sys.schemas WHERE name = 'process_managers')
 BEGIN
-	CREATE DATABASE [kafkaflowtest]
+	EXEC ('CREATE SCHEMA [process_managers] AUTHORIZATION [dbo]')
 END
 GO

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0002.Table.sql
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0002.Table.sql
@@ -1,0 +1,16 @@
+/* Table */
+CREATE TABLE [kafkaflowtest].[dbo].[processes](
+	[sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
+	[process_type] [nvarchar](255) NOT NULL,
+	[process_id] [uniqueidentifier] NOT NULL,
+	[process_state] [nvarchar](max) NOT NULL,
+    [date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+    [date_updated_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+    [rowversion] [int] NOT NULL DEFAULT(1),
+	CONSTRAINT [PK_processes] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
+	CONSTRAINT [CK_process_state_not_blank_or_empty] CHECK ((TRIM([process_state])<>N''))
+)
+GO
+
+CREATE UNIQUE NONCLUSTERED INDEX [IX_processes] ON [kafkaflowtest].[dbo].[processes] ([process_type] ASC,[process_id] ASC) WITH (FILLFACTOR = 90)
+GO

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0002.Table.sql
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0002.Table.sql
@@ -1,18 +1,17 @@
 /* Table */
-IF OBJECT_ID(N'[kafkaflowtest].[dbo].[processes]', N'U') IS NULL
+IF OBJECT_ID(N'[process_managers].[processes]', N'U') IS NULL
 BEGIN
-    CREATE TABLE [kafkaflowtest].[dbo].[processes](
-	    [sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
-	    [process_type] [nvarchar](255) NOT NULL,
-	    [process_id] [uniqueidentifier] NOT NULL,
-	    [process_state] [nvarchar](max) NOT NULL,
-        [date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
-        [date_updated_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
-        [rowversion] [int] NOT NULL DEFAULT(1),
-	    CONSTRAINT [PK_processes] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
-	    CONSTRAINT [CK_process_state_not_blank_or_empty] CHECK ((TRIM([process_state])<>N''))
-    );
+	CREATE TABLE [process_managers].[processes](
+		[sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
+		[process_type] [nvarchar](255) NOT NULL,
+		[process_id] [uniqueidentifier] NOT NULL,
+		[process_state] [nvarchar](max) NOT NULL,
+		[date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+		[date_updated_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+		[rowversion] [int] NOT NULL DEFAULT(1),
+		CONSTRAINT [PK_processes] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
+		CONSTRAINT [CK_process_state_not_blank_or_empty] CHECK ((TRIM([process_state])<>N''))
+	);
 
-    CREATE UNIQUE NONCLUSTERED INDEX [IX_processes] ON [kafkaflowtest].[dbo].[processes] ([process_type] ASC,[process_id] ASC) WITH (FILLFACTOR = 90);
+	CREATE UNIQUE NONCLUSTERED INDEX [IX_processes] ON [process_managers].[processes] ([process_type] ASC,[process_id] ASC) WITH (FILLFACTOR = 90);
 END
-GO

--- a/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0002.Table.sql
+++ b/src/Contrib.KafkaFlow.ProcessManagers.SqlServer/schema/0002.Table.sql
@@ -1,16 +1,18 @@
 /* Table */
-CREATE TABLE [kafkaflowtest].[dbo].[processes](
-	[sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
-	[process_type] [nvarchar](255) NOT NULL,
-	[process_id] [uniqueidentifier] NOT NULL,
-	[process_state] [nvarchar](max) NOT NULL,
-    [date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
-    [date_updated_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
-    [rowversion] [int] NOT NULL DEFAULT(1),
-	CONSTRAINT [PK_processes] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
-	CONSTRAINT [CK_process_state_not_blank_or_empty] CHECK ((TRIM([process_state])<>N''))
-)
-GO
+IF OBJECT_ID(N'[kafkaflowtest].[dbo].[processes]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [kafkaflowtest].[dbo].[processes](
+	    [sequence_id] [bigint] IDENTITY(1,1) NOT NULL,
+	    [process_type] [nvarchar](255) NOT NULL,
+	    [process_id] [uniqueidentifier] NOT NULL,
+	    [process_state] [nvarchar](max) NOT NULL,
+        [date_added_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+        [date_updated_utc] [datetime2] NOT NULL DEFAULT(SYSUTCDATETIME()),
+        [rowversion] [int] NOT NULL DEFAULT(1),
+	    CONSTRAINT [PK_processes] PRIMARY KEY CLUSTERED ([sequence_id] ASC),
+	    CONSTRAINT [CK_process_state_not_blank_or_empty] CHECK ((TRIM([process_state])<>N''))
+    );
 
-CREATE UNIQUE NONCLUSTERED INDEX [IX_processes] ON [kafkaflowtest].[dbo].[processes] ([process_type] ASC,[process_id] ASC) WITH (FILLFACTOR = 90)
+    CREATE UNIQUE NONCLUSTERED INDEX [IX_processes] ON [kafkaflowtest].[dbo].[processes] ([process_type] ASC,[process_id] ASC) WITH (FILLFACTOR = 90);
+END
 GO

--- a/src/Contrib.KafkaFlow.ProcessManagers/Contrib.KafkaFlow.ProcessManagers.csproj
+++ b/src/Contrib.KafkaFlow.ProcessManagers/Contrib.KafkaFlow.ProcessManagers.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="KafkaFlow.Abstractions" Version="3.0.3" />
+      <PackageReference Include="KafkaFlow.Abstractions" Version="3.0.7" />
       <PackageReference Include="KafkaFlow.TypedHandler" Version="2.5.1" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Contrib.KafkaFlow.SqlServer/Contrib.KafkaFlow.SqlServer.csproj
+++ b/src/Contrib.KafkaFlow.SqlServer/Contrib.KafkaFlow.SqlServer.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Contrib.KafkaFlow.SqlServer/ServiceCollectionExtensions.cs
+++ b/src/Contrib.KafkaFlow.SqlServer/ServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KafkaFlow.SqlServer;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, IConfiguration configuration)
+        => services.Configure<SqlServerOptions>(configuration);
+
+    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, Action<SqlServerOptions> configureOptions)
+        => services.Configure<SqlServerOptions>(configureOptions);
+
+    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, IConfiguration configuration, Action<BinderOptions>? configureBinder)
+        => services.Configure<SqlServerOptions>(configuration, configureBinder);
+
+    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, string? name, IConfiguration configuration)
+        => services.Configure<SqlServerOptions>(name, configuration);
+
+    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, string? name, Action<SqlServerOptions> configureOptions)
+        => services.Configure<SqlServerOptions>(name, configureOptions);
+
+    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureBinder)
+        => services.Configure<SqlServerOptions>(name, configuration, configureBinder);
+}

--- a/src/Contrib.KafkaFlow.SqlServer/ServiceCollectionExtensions.cs
+++ b/src/Contrib.KafkaFlow.SqlServer/ServiceCollectionExtensions.cs
@@ -5,21 +5,21 @@ namespace KafkaFlow.SqlServer;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, IConfiguration configuration)
-        => services.Configure<SqlServerOptions>(configuration);
+    public static IServiceCollection ConfigureSqlServerBackend(this IServiceCollection services, IConfiguration configuration)
+        => services.Configure<SqlServerBackendOptions>(configuration);
 
-    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, Action<SqlServerOptions> configureOptions)
-        => services.Configure<SqlServerOptions>(configureOptions);
+    public static IServiceCollection ConfigureSqlServerBackend(this IServiceCollection services, Action<SqlServerBackendOptions> configureOptions)
+        => services.Configure<SqlServerBackendOptions>(configureOptions);
 
-    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, IConfiguration configuration, Action<BinderOptions>? configureBinder)
-        => services.Configure<SqlServerOptions>(configuration, configureBinder);
+    public static IServiceCollection ConfigureSqlServerBackend(this IServiceCollection services, IConfiguration configuration, Action<BinderOptions>? configureBinder)
+        => services.Configure<SqlServerBackendOptions>(configuration, configureBinder);
 
-    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, string? name, IConfiguration configuration)
-        => services.Configure<SqlServerOptions>(name, configuration);
+    public static IServiceCollection ConfigureSqlServerBackend(this IServiceCollection services, string? name, IConfiguration configuration)
+        => services.Configure<SqlServerBackendOptions>(name, configuration);
 
-    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, string? name, Action<SqlServerOptions> configureOptions)
-        => services.Configure<SqlServerOptions>(name, configureOptions);
+    public static IServiceCollection ConfigureSqlServerBackend(this IServiceCollection services, string? name, Action<SqlServerBackendOptions> configureOptions)
+        => services.Configure<SqlServerBackendOptions>(name, configureOptions);
 
-    public static IServiceCollection ConfigureSqlServer(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureBinder)
-        => services.Configure<SqlServerOptions>(name, configuration, configureBinder);
+    public static IServiceCollection ConfigureSqlServerBackend(this IServiceCollection services, string? name, IConfiguration configuration, Action<BinderOptions>? configureBinder)
+        => services.Configure<SqlServerBackendOptions>(name, configuration, configureBinder);
 }

--- a/src/Contrib.KafkaFlow.SqlServer/SqlServerBackendOptions.cs
+++ b/src/Contrib.KafkaFlow.SqlServer/SqlServerBackendOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace KafkaFlow.SqlServer;
+
+public record SqlServerBackendOptions
+{
+    public required string ConnectionString { get; set; }
+}

--- a/src/Contrib.KafkaFlow.SqlServer/SqlServerOptions.cs
+++ b/src/Contrib.KafkaFlow.SqlServer/SqlServerOptions.cs
@@ -1,6 +1,0 @@
-﻿namespace KafkaFlow.SqlServer;
-
-public record SqlServerOptions
-{
-    public required string ConnectionString { get; init; }
-}

--- a/src/Contrib.KafkaFlow.SqlServer/SqlServerOptions.cs
+++ b/src/Contrib.KafkaFlow.SqlServer/SqlServerOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace KafkaFlow.SqlServer;
+
+public record SqlServerOptions
+{
+    public required string ConnectionString { get; init; }
+}

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/Fixture/PostgresKafkaFlowFixture.cs
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/Fixture/PostgresKafkaFlowFixture.cs
@@ -1,0 +1,126 @@
+using Confluent.Kafka;
+using KafkaFlow.Consumers;
+using KafkaFlow.Outbox;
+using KafkaFlow.Outbox.Postgres;
+using KafkaFlow.ProcessManagers.Postgres;
+using KafkaFlow.Serializer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace KafkaFlow.ProcessManagers.IntegrationTests.Fixture;
+
+public class PostgresKafkaFlowFixture : IDisposable, IAsyncDisposable
+{
+    public readonly string FixtureId = Guid.NewGuid().ToString();
+    public string TopicName { get; }
+    public readonly ServiceProvider ServiceProvider;
+    private readonly IKafkaBus _kafkaBus;
+    private readonly CancellationTokenSource _fixtureCancellation;
+
+    public LoggingProcessStateStore ProcessStateStore { get; }
+
+    public IMessageProducer Producer { get; }
+
+    public PostgresKafkaFlowFixture()
+    {
+        _fixtureCancellation = new CancellationTokenSource();
+        TopicName = $"pg-messages-{FixtureId}";
+
+        var services = new ServiceCollection();
+
+        var config = new ConfigurationManager()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connStr = config.GetConnectionString("PostgresBackend");
+        var pool = new NpgsqlDataSourceBuilder(connStr).Build();
+
+        services
+            .AddSingleton<IConfiguration>(config)
+            .AddSingleton(pool)
+            .AddLogging(log => log.AddConsole().AddDebug())
+            .AddPostgresProcessManagerState()
+            .Decorate<IProcessStateStore, LoggingProcessStateStore>()
+            .AddPostgresOutboxBackend()
+            .AddKafka(kafka =>
+                kafka
+                    .UseMicrosoftLog()
+                    .AddCluster(cluster =>
+                        cluster
+                            .WithBrokers(new[] { "localhost:9092 " })
+                            .CreateTopicIfNotExists(TopicName, 3, 1)
+                            .AddOutboxDispatcher(x => x.WithPartitioner(Partitioner.Murmur2Random))
+                            .AddProducer<PostgresKafkaFlowFixture>(producer =>
+                                producer
+                                    .WithOutbox()
+                                    .DefaultTopic(TopicName)
+                                    .AddMiddlewares(m => m.AddSerializer<JsonCoreSerializer>()))
+                            .AddProducer<ITestMessageProducer>(producer =>
+                                producer
+                                    .WithOutbox()
+                                    .DefaultTopic(TopicName)
+                                    .AddMiddlewares(m => m.AddSerializer<JsonCoreSerializer>())
+                                )
+                            .AddConsumer(consumer =>
+                                consumer
+                                    .Topic(TopicName)
+                                    .WithGroupId($"pg-group-{FixtureId}")
+                                    .WithBufferSize(100)
+                                    .WithWorkersCount(1)
+                                    .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+                                    .AddMiddlewares(middlewares =>
+                                        middlewares
+                                            .AddDeserializer<JsonCoreDeserializer>()
+                                            .AddProcessManagers(pm => pm.AddProcessManagersFromAssemblyOf<PostgresKafkaFlowFixture>())
+                                        )
+                            )
+                    )
+            );
+        ServiceProvider = services.BuildServiceProvider();
+
+        ProcessStateStore = (LoggingProcessStateStore)ServiceProvider.GetRequiredService<IProcessStateStore>();
+
+        Producer = ServiceProvider.GetRequiredService<IMessageProducer<PostgresKafkaFlowFixture>>();
+
+        var svc = ServiceProvider.GetServices<IHostedService>();
+
+        foreach (var service in svc)
+        {
+            service.StartAsync(_fixtureCancellation.Token);
+        }
+
+        _kafkaBus = ServiceProvider.CreateKafkaBus();
+        _kafkaBus.StartAsync(_fixtureCancellation.Token);
+    }
+
+    public void Dispose()
+    {
+        if (!_disposedAsync)
+        {
+            DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+    }
+
+    private bool _disposedAsync = false;
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposedAsync = true;
+
+        _fixtureCancellation.Cancel();
+        _fixtureCancellation.Dispose();
+        await _kafkaBus.StopAsync();
+
+        foreach (var cons in ServiceProvider.GetRequiredService<IConsumerAccessor>().All)
+        {
+            await cons.StopAsync();
+        }
+
+        await ServiceProvider.DisposeAsync();
+    }
+}

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/Fixture/SqlServerKafkaFlowFixture.cs
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/Fixture/SqlServerKafkaFlowFixture.cs
@@ -4,12 +4,10 @@ using KafkaFlow.Outbox;
 using KafkaFlow.Outbox.SqlServer;
 using KafkaFlow.ProcessManagers.SqlServer;
 using KafkaFlow.Serializer;
-using KafkaFlow.SqlServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace KafkaFlow.ProcessManagers.IntegrationTests.Fixture;
 
@@ -38,13 +36,10 @@ public class SqlServerKafkaFlowFixture : IDisposable, IAsyncDisposable
             .AddEnvironmentVariables()
             .Build();
 
-        var connStr = config.GetConnectionString("SqlServerBackend");
-
         services
             .AddSingleton<IConfiguration>(config)
-            .AddSingleton(Options.Create(new SqlServerOptions { ConnectionString = connStr }))
             .AddLogging(log => log.AddConsole().AddDebug())
-            .AddSqlServerProcessManagerState()
+            .AddSqlServerProcessManagerState(config.GetConnectionString("SqlServerBackend"))
             .Decorate<IProcessStateStore, LoggingProcessStateStore>()
             .AddSqlServerOutboxBackend()
             .AddKafka(kafka =>

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/KafkaFlow.ProcessManagers.IntegrationTests.csproj
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/KafkaFlow.ProcessManagers.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -35,9 +35,12 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Contrib.KafkaFlow.Outbox.Postgres\Contrib.KafkaFlow.Outbox.Postgres.csproj" />
+      <ProjectReference Include="..\..\src\Contrib.KafkaFlow.Outbox.SqlServer\Contrib.KafkaFlow.Outbox.SqlServer.csproj" />
       <ProjectReference Include="..\..\src\Contrib.KafkaFlow.Outbox\Contrib.KafkaFlow.Outbox.csproj" />
       <ProjectReference Include="..\..\src\Contrib.KafkaFlow.ProcessManagers.Postgres\Contrib.KafkaFlow.ProcessManagers.Postgres.csproj" />
+      <ProjectReference Include="..\..\src\Contrib.KafkaFlow.ProcessManagers.SqlServer\Contrib.KafkaFlow.ProcessManagers.SqlServer.csproj" />
       <ProjectReference Include="..\..\src\Contrib.KafkaFlow.ProcessManagers\Contrib.KafkaFlow.ProcessManagers.csproj" />
+      <ProjectReference Include="..\..\src\Contrib.KafkaFlow.SqlServer\Contrib.KafkaFlow.SqlServer.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/KafkaFlow.ProcessManagers.IntegrationTests.csproj
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/KafkaFlow.ProcessManagers.IntegrationTests.csproj
@@ -11,23 +11,23 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="KafkaFlow" Version="3.0.3" />
-        <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.0.3" />
-        <PackageReference Include="KafkaFlow.LogHandler.Microsoft" Version="3.0.3" />
-        <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.3" />
-        <PackageReference Include="KafkaFlow.Serializer.JsonCore" Version="3.0.3" />
+        <PackageReference Include="KafkaFlow" Version="3.0.7" />
+        <PackageReference Include="KafkaFlow.LogHandler.Console" Version="3.0.7" />
+        <PackageReference Include="KafkaFlow.LogHandler.Microsoft" Version="3.0.7" />
+        <PackageReference Include="KafkaFlow.Microsoft.DependencyInjection" Version="3.0.7" />
+        <PackageReference Include="KafkaFlow.Serializer.JsonCore" Version="3.0.7" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit" Version="2.6.6" />
+        <PackageReference Include="xunit" Version="2.7.1" />
         <PackageReference Include="xunit.assemblyfixture" Version="2.2.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/SqlServerProcessManagerStoreTests.cs
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/SqlServerProcessManagerStoreTests.cs
@@ -1,8 +1,7 @@
 ﻿using FluentAssertions;
 using KafkaFlow.ProcessManagers.SqlServer;
-using KafkaFlow.SqlServer;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace KafkaFlow.ProcessManagers.IntegrationTests;
 public sealed class SqlServerProcessManagerStoreTests
@@ -20,9 +19,11 @@ public sealed class SqlServerProcessManagerStoreTests
                 .AddEnvironmentVariables()
                 .Build();
 
-        var connStr = config.GetConnectionString("SqlServerBackend");
+        var services = new ServiceCollection();
+        services.AddSqlServerProcessManagerState(config.GetConnectionString("SqlServerBackend"));
+        var sp = services.BuildServiceProvider();
 
-        var store = new SqlServerProcessManagersStore(Options.Create(new SqlServerOptions { ConnectionString = connStr }));
+        var store = sp.GetRequiredService<IProcessStateStore>();
 
         var noState = await store.Load(state.GetType(), processId);
         noState.Should().BeEquivalentTo(VersionedState.Zero);

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/SqlServerProcessManagerStoreTests.cs
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/SqlServerProcessManagerStoreTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using KafkaFlow.ProcessManagers.SqlServer;
+using KafkaFlow.SqlServer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace KafkaFlow.ProcessManagers.IntegrationTests;
+public sealed class SqlServerProcessManagerStoreTests
+{
+    [Fact]
+    public async Task Should_write_update_and_delete_state()
+    {
+        var processId = Guid.NewGuid();
+        var state = processId.ToString();
+
+        var config =
+            new ConfigurationManager()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false)
+                .AddEnvironmentVariables()
+                .Build();
+
+        var connStr = config.GetConnectionString("SqlServerBackend");
+
+        var store = new SqlServerProcessManagersStore(Options.Create(new SqlServerOptions { ConnectionString = connStr }));
+
+        var noState = await store.Load(state.GetType(), processId);
+        noState.Should().BeEquivalentTo(VersionedState.Zero);
+
+        await store.Persist(state.GetType(), processId, new VersionedState(0, state));
+
+        var hasState = await store.Load(state.GetType(), processId);
+        hasState.State.Should().NotBeNull();
+        hasState.Version.Should().BePositive();
+
+        await store.Delete(state.GetType(), processId, hasState.Version);
+        var goneState = await store.Load(state.GetType(), processId);
+        goneState.Should().BeEquivalentTo(VersionedState.Zero);
+    }
+}

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/UserLifeCycle/PostgresUserLifecycleProcessManagerTests.cs
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/UserLifeCycle/PostgresUserLifecycleProcessManagerTests.cs
@@ -3,11 +3,11 @@ using KafkaFlow.ProcessManagers.IntegrationTests.Fixture;
 
 namespace KafkaFlow.ProcessManagers.IntegrationTests.UserLifeCycle;
 
-public sealed class UserLifecycleProcessManagerTests : IAssemblyFixture<KafkaFlowFixture>
+public sealed class PostgresUserLifecycleProcessManagerTests : IAssemblyFixture<PostgresKafkaFlowFixture>
 {
-    private readonly KafkaFlowFixture _fixture;
+    private readonly PostgresKafkaFlowFixture _fixture;
 
-    public UserLifecycleProcessManagerTests(KafkaFlowFixture fixture)
+    public PostgresUserLifecycleProcessManagerTests(PostgresKafkaFlowFixture fixture)
     {
         _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
         _fixture.ProcessStateStore.ClearChanges();

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/UserLifeCycle/SqlServerLifecycleProcessManagerTests.cs
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/UserLifeCycle/SqlServerLifecycleProcessManagerTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using KafkaFlow.ProcessManagers.IntegrationTests.Fixture;
+
+namespace KafkaFlow.ProcessManagers.IntegrationTests.UserLifeCycle;
+
+public sealed class SqlServerLifecycleProcessManagerTests : IAssemblyFixture<SqlServerKafkaFlowFixture>
+{
+    private readonly SqlServerKafkaFlowFixture _fixture;
+
+    public SqlServerLifecycleProcessManagerTests(SqlServerKafkaFlowFixture fixture)
+    {
+        _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        _fixture.ProcessStateStore.ClearChanges();
+    }
+
+    [Fact]
+    public async Task Should_run_user_registration_simulation()
+    {
+        var message = new UserRegistered(Guid.NewGuid(), "test@test.com");
+        await _fixture.Producer.ProduceAsync(message.UserId.ToString(), message);
+
+        TestUtils.RetryFor(TimeSpan.FromSeconds(30), TimeSpan.FromMicroseconds(100), () =>
+        {
+            _fixture.ProcessStateStore
+                .Changes
+                .Select(x => x.Item1)
+                .Should().BeEquivalentTo(new[]
+                {
+                    LoggingProcessStateStore.ActionType.Persisted,
+                    LoggingProcessStateStore.ActionType.Persisted,
+                    LoggingProcessStateStore.ActionType.Deleted
+                }, x => x.WithStrictOrdering());
+        });
+    }
+}

--- a/tests/KafkaFlow.ProcessManagers.IntegrationTests/appsettings.json
+++ b/tests/KafkaFlow.ProcessManagers.IntegrationTests/appsettings.json
@@ -1,5 +1,6 @@
 {
   "ConnectionStrings": {
-    "PostgresBackend": "Host=localhost;Username=postgres;Password=postgres;Database=postgres"
+    "PostgresBackend": "Host=localhost;Username=postgres;Password=postgres;Database=postgres",
+    "SqlServerBackend": "Server=localhost;User Id=SA;Password=4YiUmU2YJ8$6eqbSXF8765Ck3;Database=kafkaflowtest"
   }
 }


### PR DESCRIPTION
This PR adds a Microsoft SQL Server implementation.

I have 'ported' the Postgres SQL statements to T-SQL as closely as I could. One thing I ran into is that the rowversion mechanism differs quite much between the two. As far as I could see the Outbox doesn't seem to use the rowversion anywhere(?), and I tried to keep the ProcessManager as close to the Postgres version as possible. One of the issues I had was that a rowversion (or timestamp) in Sql Server is an 8 byte (64 bit) value, however, the `VersionedState` requires an `int` for the version and since there's no (safe) way to convert a 64 bit value to a 32 bit value I opted to 'DIY' the rowversion; the `MERGE` statement should be atomic.

It's also not very clear to me what use the `date_added_utc` and `date_updated_utc` fields have, but maybe I'm missing some implementation details that Postgres has that I'm not aware of. I did keep (and populate) them in the Sql Server variant where applicable.

Also, there weren't (and aren't) any integrationtests as far as I can see for the Outbox. Again, I tried to keep this as close as possible to the Postgres variant but I haven't tested it (yet).

In the integrationtests project I renamed the `KafkaFlowFixture` to a more specific `PostgreKafkaFlowFixture` and then copied it to a `SqlServerKafkaFlowFixture` and changed it to work with SqlServer. Same goes for the `LifecycleProcessManagerTests` which I renamed to `PostgresLifecycleProcessManagerTests` and copied to `SqlServerLifecycleProcessManagerTests` and changed to work with SqlServer. This may need some work to de-duplicate (DRY) some of the integrationtests.

So, things that need attention:

* Rowversion
* Outbox isn't tested
* Integrationtests code duplication

Since Sql Server (or rather: the `SqlClient`) [handles connection pooling](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql-server-connection-pooling) internally we don't need to set up a pool like in the Postgres variant. I did, however, have to create a small shared, common library called `Contrib.KafkaFlow.SqlServer` which is used by both `KafkaFlow.Outbox.SqlServer` and `KafkaFlow.ProcessManagers.SqlServer`. This library only contains a few extension methods to configure Sql Server usage and a `SqlServerOptions` record so we don't have to pass a "bare" connectionstring to the `SqlServerOutboxBackend` and `SqlServerProcessManagersStore` classes.

Other than that, I think this should at least be a good start for a SqlServer implementation.

~~⚠️  I couldn't get the `initdb.sh` script to trigger under the `mssql` container. I have a few solutions/workarounds but I am still deciding which one to use. Your opinion / help would be very much appreciated. For now you'll need to run the `/docker-entrypoint-initdb.d/initdb.sh` script manually before running the integrationtests.~~ Fixed in 7385102

Oh, one more thing: It isn't very clear to me how you'd use this library in an existing project. I assume the developer is expected to create the `outbox` and `processes` tables "manually"? I would expect the table(s) creation to be handled either on demand by invoking some method or automatically the first time the database is approached or something?

Finally: I have some other ideas / plans:

* [X] I'd like to get rid of a lot of compiler warnings (4 currently) and messages (27 currently) by 'modernizing' the code a little (like using primary constructors, collection initializers etc)
  **EDIT:** Most of this is done (see [this branch](https://github.com/RobThree/kafkaflow-contrib/tree/modernize)). I'll create a new PR for this once this one has been merged.
* [X] I'd like to try lowering the requirement for .Net to, say .Net 7, 6, or even better: .Net Standard 2.0/2.1 or so, without too much effort or breaking stuff for broader platform support.
  **EDIT:** Done; I managed to lower the requirement to .Net Standard 2.0 (see [this branch](https://github.com/RobThree/kafkaflow-contrib/tree/lower-framework-support) or [this commit](https://github.com/RobThree/kafkaflow-contrib/commit/e6bbacdb521149c3df50e7224c3793aa7b7961bb)). This means that even .Net Framework developers can use this library. I'll create a new PR for this once this one and the 'modernize' one (above) has been merged.
* [X] I referred to code duplication earlier in the integrationtests, but the actual implementations of the Postgres and SQL Server variants are also _very close_ implementation-wise; I'd like to see if that could be relieved or solved by introducing some interfaces and making the code a little more generic.
  **EDIT:** Done. See [this branch](https://github.com/RobThree/kafkaflow-contrib/tree/code-deduplication)
* [X] Use a schema as per @kchenery remarks: Done, see [this branch](https://github.com/RobThree/kafkaflow-contrib/tree/mssql-use-schema)
* [ ] This project should have a LICENSE. Not sure what you prefer, but KafkaFlow is MIT and I usually also use MIT; but that's ofcourse 100% up to you.