### PR TITLE
Migrate sequence_id to BIGSERIAL

### DIFF
--- a/src/Contrib.KafkaFlow.Outbox.Postgres/schema/0003.Bigserial.sql
+++ b/src/Contrib.KafkaFlow.Outbox.Postgres/schema/0003.Bigserial.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "outbox"."outbox" ALTER COLUMN "sequence_id" TYPE BIGINT;

--- a/src/Contrib.KafkaFlow.ProcessManagers.Postgres/schema/0003.BigSerial.sql
+++ b/src/Contrib.KafkaFlow.ProcessManagers.Postgres/schema/0003.BigSerial.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "process_managers"."processes" ALTER COLUMN "sequence_id" TYPE BIGINT;


### PR DESCRIPTION
Looks like your model already uses `long`. And the tests pass so I think this is ok as is.