### PR TITLE
Allow transaction scope to be customised

### DIFF
--- a/src/Contrib.KafkaFlow.Outbox/IOutboxBackend.cs
+++ b/src/Contrib.KafkaFlow.Outbox/IOutboxBackend.cs
@@ -1,8 +1,12 @@
 using Confluent.Kafka;
 
 namespace KafkaFlow.Outbox;
+
+
 public interface IOutboxBackend
 {
+    public ITransactionScope BeginTransaction();
+
     ValueTask Store(TopicPartition topicPartition, Message<byte[], byte[]> message, CancellationToken token2 = default);
     ValueTask<OutboxRecord[]> Read(int batchSize, CancellationToken token = default);
 }

--- a/src/Contrib.KafkaFlow.Outbox/IOutboxRepository.cs
+++ b/src/Contrib.KafkaFlow.Outbox/IOutboxRepository.cs
@@ -1,7 +1,31 @@
-﻿namespace KafkaFlow.Outbox;
+﻿using System.Transactions;
+
+namespace KafkaFlow.Outbox;
 
 public interface IOutboxRepository
 {
     ValueTask Store(OutboxTableRow outboxTableRow, CancellationToken token = default);
     Task<IEnumerable<OutboxTableRow>> Read(int batchSize, CancellationToken token = default);
+
+
+    /// <summary>
+    /// Creates a new transaction scope for the outbox operations.
+    /// By default, it uses a new transaction scope with the `RequiresNew` option,
+    /// but repositories can override this method to provide a custom transaction scope.
+    /// </summary>
+    /// <remarks>
+    /// Not all the backends support TransactionScope and can enlist in an ambient transaction.
+    /// For example, the MongoDB backend cannot do it, as MongoDB has its own transaction management.
+    /// Having this method allows the repository to provide a custom transaction scope, which can then
+    /// be respected by the dispatcher service to ensure that the outbox operations are executed
+    /// in the same transaction as the Kafka producer operations.
+    /// </remarks>
+    ITransactionScope BeginTransaction()
+    {
+        return new WrappedTransactionScope(new(
+            scopeOption: TransactionScopeOption.RequiresNew,
+            transactionOptions: new TransactionOptions
+                { IsolationLevel = IsolationLevel.ReadCommitted, Timeout = TimeSpan.FromSeconds(30) },
+            asyncFlowOption: TransactionScopeAsyncFlowOption.Enabled));
+    }
 }

--- a/src/Contrib.KafkaFlow.Outbox/InMemory/InMemoryOutboxBackend.cs
+++ b/src/Contrib.KafkaFlow.Outbox/InMemory/InMemoryOutboxBackend.cs
@@ -3,9 +3,17 @@ using System.Collections.Concurrent;
 
 namespace KafkaFlow.Outbox.InMemory;
 
+file sealed class NoOpTransactionScope : ITransactionScope
+{
+    public void Complete() { }
+    public void Dispose() { }
+}
+
 public sealed class InMemoryOutboxBackend : IOutboxBackend
 {
     private readonly ConcurrentQueue<(TopicPartition, Message<byte[], byte[]>)> _queue = new();
+
+    public ITransactionScope BeginTransaction() => new NoOpTransactionScope();
 
     public ValueTask Store(TopicPartition topicPartition, Message<byte[], byte[]> message, CancellationToken token = default)
     {

--- a/src/Contrib.KafkaFlow.Outbox/OutboxDispatcherService.cs
+++ b/src/Contrib.KafkaFlow.Outbox/OutboxDispatcherService.cs
@@ -39,7 +39,7 @@ internal sealed class OutboxDispatcherService(
 
     private async Task<DispatchBatchResult> DispatchNextBatchAsync(CancellationToken stoppingToken)
     {
-        using var scope = BeginTransaction;
+        using var scope = _outboxBackend.BeginTransaction();
         try
         {
             var batch = await _outboxBackend.Read(10, stoppingToken).ConfigureAwait(false);
@@ -68,12 +68,6 @@ internal sealed class OutboxDispatcherService(
     private MessageHeaders? BuildHeaders(OutboxRecord record) =>
         record.Message.Headers == null ? null : new MessageHeaders(record.Message.Headers);
 
-    private static TransactionScope BeginTransaction =>
-        new(
-            scopeOption: TransactionScopeOption.RequiresNew,
-            transactionOptions: new TransactionOptions
-            { IsolationLevel = IsolationLevel.ReadCommitted, Timeout = TimeSpan.FromSeconds(30) },
-            asyncFlowOption: TransactionScopeAsyncFlowOption.Enabled);
 
     private abstract record DispatchBatchResult
     {

--- a/src/Contrib.KafkaFlow.Outbox/TransactionScope.cs
+++ b/src/Contrib.KafkaFlow.Outbox/TransactionScope.cs
@@ -1,0 +1,14 @@
+using System.Transactions;
+
+namespace KafkaFlow.Outbox;
+
+public interface ITransactionScope : IDisposable
+{
+    void Complete();
+}
+
+internal sealed class WrappedTransactionScope(TransactionScope scope) : ITransactionScope
+{
+    public void Complete() => scope.Complete();
+    public void Dispose() => scope.Dispose();
+}


### PR DESCRIPTION
+semver:minor
## Description

In order to support backends that don't interop with `TransactionScope`, allow transaction management at the level of specific backends.