### PR TITLE
Make Store side transactional and enforce it a bit

### DIFF
--- a/src/Contrib.KafkaFlow.Outbox.MongoDb/MongoDbTransactionScope.cs
+++ b/src/Contrib.KafkaFlow.Outbox.MongoDb/MongoDbTransactionScope.cs
@@ -1,9 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
 using KafkaFlow.Outbox;
 using MongoDB.Driver;
 
 namespace Contrib.KafkaFlow.Outbox.MongoDb;
 
-internal sealed class MongoDbTransactionScope : ITransactionScope
+/// <summary>
+/// <para>
+/// Represents a transaction scope for MongoDB operations with session ownership management.
+/// </para>
+/// <para>
+/// This class manages the lifecycle of a MongoDB session, allowing for transaction management
+/// and ensuring that operations can be committed or rolled back. It uses an AsyncLocal to make
+/// the session available to repository operations throughout the current execution context.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The scope implements a "Required" transaction pattern that supports nested scopes:
+/// </para>
+/// <list type="bullet">
+/// <item><description>If an existing session is already active, it reuses that session without taking ownership</description></item>
+/// <item><description>If no session exists, it creates a new session and takes ownership of it</description></item>
+/// </list>
+/// <para>
+/// <strong>Session Ownership:</strong> Only scopes that own their session will manage transaction lifecycle.
+/// Nested scopes that reuse existing sessions will not commit or abort transactions.
+/// </para>
+/// <para>
+/// <strong>Transaction Support:</strong> The scope automatically detects if the MongoDB server supports
+/// transactions. If transactions are not supported (e.g., standalone servers), operations will still
+/// work but without transactional guarantees.
+/// </para>
+/// <para>
+/// <strong>Transaction Lifecycle:</strong> For owned sessions only:
+/// </para>
+/// <list type="bullet">
+/// <item><description>If <c>Complete()</c> is called before disposal, the transaction will be committed</description></item>
+/// <item><description>If <c>Complete()</c> is not called, the transaction will be aborted upon disposal</description></item>
+/// <item><description>Non-owned sessions (nested scopes) are not affected by <c>Complete()</c> or disposal</description></item>
+/// </list>
+/// </remarks>
+public sealed class MongoDbTransactionScope : ITransactionScope
 {
     private readonly IClientSessionHandle? _session;
     private readonly bool _supportsTransactions;
@@ -15,7 +52,78 @@ internal sealed class MongoDbTransactionScope : ITransactionScope
     // AsyncLocal to make session available to repository operations
     private static readonly AsyncLocal<IClientSessionHandle?> CurrentSessionRef = new();
 
+    /// <summary>
+    /// Gets a value indicating whether there is an active MongoDB session in the current execution context.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if a session is available; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// This property can be used to check if MongoDB operations will have access to a session
+    /// without needing to access the session itself.
+    /// </remarks>
+    public static bool HasSession => CurrentSessionRef.Value != null;
+
+    /// <summary>
+    /// Gets the current MongoDB session available in the execution context, if any.
+    /// </summary>
+    /// <value>
+    /// The current <see cref="IClientSessionHandle"/> if available; otherwise, <c>null</c>.
+    /// </value>
+    /// <remarks>
+    /// <para>
+    /// This property provides access to the MongoDB session that can be used by repository operations
+    /// to ensure they participate in the current transaction scope.
+    /// </para>
+    /// <para>
+    /// The session is managed through AsyncLocal, making it available throughout the current
+    /// execution context including async operations.
+    /// </para>
+    /// </remarks>
     public static IClientSessionHandle? CurrentSession => CurrentSessionRef.Value;
+
+    /// <summary>
+    /// Gets a value indicating whether the current scope supports MongoDB transactions.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the scope can perform transactional operations; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// <para>
+    /// This property indicates whether the MongoDB server and configuration support transactions.
+    /// It will be <c>false</c> for standalone MongoDB servers or when session creation fails.
+    /// </para>
+    /// <para>
+    /// Even when transactions are not supported, the scope can still provide session consistency
+    /// for read operations.
+    /// </para>
+    /// </remarks>
+    public bool SupportsTransactions => _supportsTransactions;
+
+    /// <summary>
+    /// Attempts to get the current MongoDB session from the execution context.
+    /// </summary>
+    /// <param name="session">
+    /// When this method returns, contains the current session if available; otherwise, <c>null</c>.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if a session is available in the current execution context; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This method provides a safe way to check for and retrieve the current session without
+    /// needing to handle null reference scenarios when accessing <see cref="CurrentSession"/> directly.
+    /// </para>
+    /// <para>
+    /// This is particularly useful in repository implementations that need to conditionally
+    /// use a session if available, or operate without one if not.
+    /// </para>
+    /// </remarks>
+    public static bool TryGetSession([NotNullWhen(true)] out IClientSessionHandle? session)
+    {
+        session = CurrentSessionRef.Value;
+        return session != null;
+    }
 
     // Private constructor - use Create method instead
     private MongoDbTransactionScope(IClientSessionHandle? session, bool supportsTransactions, bool ownsSession)
@@ -26,9 +134,25 @@ internal sealed class MongoDbTransactionScope : ITransactionScope
     }
 
     /// <summary>
-    /// Creates a new transaction scope. Currently behaves like "Required" -
-    /// reuses existing session if available, creates new one if not.
+    /// Creates a new MongoDB transaction scope using the "Required" transaction pattern.
     /// </summary>
+    /// <param name="client">The MongoDB client to use for creating a new session if needed.</param>
+    /// <returns>
+    /// A new <see cref="MongoDbTransactionScope"/> that either owns a new session or
+    /// reuses an existing session without ownership.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// This method implements the "Required" pattern:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>If a session already exists in the current context, it will be reused without taking ownership</description></item>
+    /// <item><description>If no session exists, a new session will be created and owned by this scope</description></item>
+    /// </list>
+    /// <para>
+    /// Only scopes that own their session will manage transaction commit/abort operations.
+    /// </para>
+    /// </remarks>
     public static MongoDbTransactionScope Create(IMongoClient client)
     {
         // Check if there's already an active session we can reuse
@@ -77,6 +201,20 @@ internal sealed class MongoDbTransactionScope : ITransactionScope
         }
     }
 
+    /// <summary>
+    /// Marks the transaction as completed, indicating it should be committed when the scope is disposed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method only affects scopes that own their session. Nested scopes that reuse existing
+    /// sessions will not perform any transaction operations when this method is called.
+    /// </para>
+    /// <para>
+    /// If the scope owns a session and supports transactions, calling this method will commit
+    /// the transaction immediately. If transactions are not supported, this method has no effect.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the scope has already been disposed.</exception>
     public void Complete()
     {
         _semaphore.Wait();
@@ -98,6 +236,26 @@ internal sealed class MongoDbTransactionScope : ITransactionScope
         }
     }
 
+    /// <summary>
+    /// Disposes the transaction scope and cleans up resources.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method only performs cleanup operations for scopes that own their session.
+    /// Nested scopes that reuse existing sessions will not dispose the session or affect transactions.
+    /// </para>
+    /// <para>
+    /// For owned sessions:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>If <c>Complete()</c> was not called and transactions are supported, the transaction will be aborted</description></item>
+    /// <item><description>The session will be disposed and removed from the current execution context</description></item>
+    /// <item><description>The AsyncLocal session reference will be cleared</description></item>
+    /// </list>
+    /// <para>
+    /// For non-owned sessions (nested scopes), this method performs no operations on the session.
+    /// </para>
+    /// </remarks>
     public void Dispose()
     {
         _semaphore.Wait();

--- a/src/Contrib.KafkaFlow.Outbox.MongoDb/MongoDbTransactionScopeRequiredException.cs
+++ b/src/Contrib.KafkaFlow.Outbox.MongoDb/MongoDbTransactionScopeRequiredException.cs
@@ -1,0 +1,57 @@
+namespace Contrib.KafkaFlow.Outbox.MongoDb;
+
+/// <summary>
+/// The exception that is thrown when an attempt is made to use MongoDB outbox operations
+/// without an active <see cref="MongoDbTransactionScope"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exception is thrown by MongoDB outbox repository operations when no transaction scope
+/// is available in the current execution context. MongoDB outbox operations require an active
+/// transaction scope to ensure data consistency and proper transaction management.
+/// </para>
+/// <para>
+/// To resolve this exception, wrap your outbox operations within a <see cref="MongoDbTransactionScope"/>:
+/// </para>
+/// <code>
+/// using var scope = MongoDbTransactionScope.Create(mongoClient);
+/// // Perform outbox operations here
+/// scope.Complete();
+/// </code>
+/// </remarks>
+public sealed class MongoDbTransactionScopeRequiredException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDbTransactionScopeRequiredException"/> class
+    /// with a default error message.
+    /// </summary>
+    public MongoDbTransactionScopeRequiredException()
+        : base("MongoDB outbox operations require an active MongoDbTransactionScope. " +
+               "Please wrap your operations within a MongoDbTransactionScope using " +
+               "MongoDbTransactionScope.Create(mongoClient).")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoDbTransactionScopeRequiredException"/> class
+    /// with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    internal MongoDbTransactionScopeRequiredException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="MongoDbTransactionScopeRequiredException"/> with a message
+    /// that includes guidance for nested scope scenarios.
+    /// </summary>
+    /// <returns>A new <see cref="MongoDbTransactionScopeRequiredException"/> instance.</returns>
+    internal static MongoDbTransactionScopeRequiredException ForMissingScope() =>
+        new(
+            "No active MongoDbTransactionScope found in the current execution context. " +
+            "MongoDB outbox operations require an active transaction scope. " +
+            "Ensure you have created a scope using MongoDbTransactionScope.Create(mongoClient) " +
+            "and that it hasn't been disposed. For nested operations, the scope must be " +
+            "created in a parent context that encompasses all repository operations.");
+}

--- a/src/Contrib.KafkaFlow.Outbox.MongoDb/Readme.md
+++ b/src/Contrib.KafkaFlow.Outbox.MongoDb/Readme.md
@@ -1,0 +1,201 @@
+# KafkaFlow MongoDB Outbox
+
+A MongoDB implementation of the [transactional outbox pattern](https://microservices.io/patterns/data/transactional-outbox.html) for KafkaFlow.
+
+## Overview
+
+This package provides MongoDB-based outbox functionality that ensures reliable message publishing by storing outbox records in MongoDB
+collections and dispatching them transactionally.
+It guarantees that your business data changes and Kafka message publishing happen atomically.
+
+## Key Features
+
+- **Transactional Consistency**: Ensures atomicity between business operations and message publishing
+- **MongoDB Native**: Built specifically for MongoDB with proper session and transaction support
+- **Distributed Locking**: Prevents multiple instances from processing the same outbox records
+- **Automatic Sequencing**: Maintains message ordering through sequence IDs
+- **Nested Scope Support**: Handles complex transaction scenarios with proper ownership management
+
+## Prerequisites
+
+- **MongoDB Replica Set or Sharded Cluster**: MongoDB transactions require a replica set or sharded cluster configuration
+- **Single Instance Limitation**: While the outbox will work with a standalone MongoDB instance, transactions are not supported,
+    and data consistency cannot be guaranteed. This configuration doesn't make much sense for the outbox pattern
+    as it defeats the purpose of transactional guarantees.
+
+## Installation
+
+```bash
+dotnet add package Contrib.KafkaFlow.Outbox.MongoDb
+```
+
+## Configuration
+
+### Basic Setup
+
+```csharp
+services
+    .AddMongoDbOutboxBackend(mongoDatabase, "my_outbox")
+    .AddKafka(kafka =>
+        kafka.AddCluster(cluster =>
+            cluster
+                .AddOutboxDispatcher()
+                .AddProducer<IMyProducer>(producer =>
+                    producer
+                        .AddMiddlewares(m => m.AddSerializer<JsonCoreSerializer>())
+                        .WithOutbox()))); // Enable outbox for this producer
+```
+
+## Usage
+
+### Required: Transaction Scope Management
+
+**Important**: All outbox operations must be wrapped in a `MongoDbTransactionScope`.
+This is mandatory and enforced by the repository - operations will throw `MongoDbTransactionScopeRequiredException`
+if no active scope is detected.
+
+### Basic Usage
+
+```csharp
+public class OrderService
+{
+    private readonly IMongoDatabase _database;
+    private readonly IOutboxProducer _outboxProducer;
+
+    public async Task CreateOrderAsync(CreateOrderRequest request)
+    {
+        // Always wrap outbox operations in a transaction scope
+        using var scope = MongoDbTransactionScope.Create(_database.Client);
+
+        // Perform your business operations
+        var order = new Order(request.CustomerId, request.Items);
+        await _ordersCollection.InsertOneAsync(scope.CurrentSession, order);
+
+        // Publish event through outbox
+        await _outboxProducer.ProduceAsync(
+            "order-events",
+            order.Id.ToString(),
+            new OrderCreatedEvent(order.Id, order.CustomerId, order.Total)
+        );
+
+        // Commit the transaction
+        scope.Complete();
+    }
+}
+```
+
+### Advanced: Nested Scopes
+
+The transaction scope supports nesting with proper ownership management:
+
+```csharp
+public async Task ComplexBusinessOperation()
+{
+    // Outer scope - owns the session
+    using var outerScope = MongoDbTransactionScope.Create(_mongoClient);
+
+    await PerformBusinessLogic();
+
+    // Inner scope - reuses existing session without ownership
+    await CallAnotherServiceMethod(); // This method can create its own scope
+
+    outerScope.Complete(); // Only the owning scope manages transaction commit
+}
+
+private async Task CallAnotherServiceMethod()
+{
+    // This scope reuses the existing session and doesn't manage transactions
+    using var innerScope = MongoDbTransactionScope.Create(_mongoClient);
+
+    await _outboxProducer.ProduceAsync("events", "key", eventData);
+
+    innerScope.Complete(); // No-op for non-owning scopes
+}
+```
+
+## Session Management
+
+### Checking Session Availability
+
+```csharp
+// Check if a session is available
+if (MongoDbTransactionScope.HasSession)
+{
+    // Session is available for operations
+}
+
+// Safely get the current session
+if (MongoDbTransactionScope.TryGetSession(out var session))
+{
+    // Use session for MongoDB operations
+    await collection.InsertOneAsync(session, document);
+}
+```
+
+### Transaction Support Detection
+
+```csharp
+using var scope = MongoDbTransactionScope.Create(_mongoClient);
+
+if (scope.SupportsTransactions)
+{
+    // Full transactional support available
+    Console.WriteLine("Running with transaction support");
+}
+else
+{
+    // Standalone MongoDB - no transactions
+    Console.WriteLine("Running without transaction support");
+}
+```
+
+## Collections and Indexes
+
+The outbox automatically creates the following collections:
+
+- **Main Collection** (default: `outbox`): Stores outbox records
+- **Lock Collection** (default: `outbox_locks`): Manages distributed locking
+
+Indexes are automatically created for optimal performance:
+- Ascending index on `SequenceId` for efficient ordering
+
+## Best Practices
+
+### 1. Always Use Transaction Scopes
+```csharp
+// ✅ Correct
+using var scope = MongoDbTransactionScope.Create(mongoClient);
+await _outboxProducer.ProduceAsync("topic", "key", data);
+scope.Complete();
+
+// ❌ Incorrect - will throw exception
+await _outboxProducer.ProduceAsync("topic", "key", data);
+```
+
+### 2. Handle Nested Operations Properly
+```csharp
+// ✅ Correct - create scope at the highest level
+using var scope = MongoDbTransactionScope.Create(mongoClient);
+await BusinessOperation1();
+await BusinessOperation2(); // These can create their own scopes
+scope.Complete();
+```
+
+## Troubleshooting
+
+### Common Exceptions
+
+**`MongoDbTransactionScopeRequiredException`**
+- **Cause**: Attempting to use outbox operations without an active transaction scope
+- **Solution**: Wrap operations in `MongoDbTransactionScope.Create(mongoClient)`
+
+### Performance Considerations
+
+- **Batch Size**: Configure appropriate batch sizes for outbox dispatching. Processing a batch must be doable withing the lock duration.
+- **Lock Duration**: Is hardcoded to be 10 seconds. Not configurable for now.
+
+## Related Documentation
+
+- [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html)
+- [MongoDB Transactions](https://docs.mongodb.com/manual/core/transactions/)
+- [KafkaFlow Documentation](https://github.com/Farfetch/kafkaflow)


### PR DESCRIPTION
## Changes

- Make storing side transaction-aware
- Enforce opening MongoDbTransactionScope explicitly
- Support non-transactional MongoDbTransactionScope sessions (for 1 instance scenarious) despite that it doesn't make sense.

Pretty much everything should be explained in comments and in Readme.