### PR TITLE
fix: 🐛 fix session disposal

### DIFF
--- a/src/Contrib.KafkaFlow.Outbox.MongoDb/MongoDbTransactionScope.cs
+++ b/src/Contrib.KafkaFlow.Outbox.MongoDb/MongoDbTransactionScope.cs
@@ -167,9 +167,10 @@ public sealed class MongoDbTransactionScope : ITransactionScope
         }
 
         // No existing session, create a new one
+        IClientSessionHandle? session = null;
         try
         {
-            var session = client.StartSession();
+            session = client.StartSession();
             var supportsTransactions = true;
 
             try
@@ -193,6 +194,7 @@ public sealed class MongoDbTransactionScope : ITransactionScope
         }
         catch (MongoException)
         {
+            session?.Dispose();
             // Other MongoDB exceptions (e.g., can't create session at all)
             CurrentSessionRef.Value = null;
             return new MongoDbTransactionScope(


### PR DESCRIPTION
If StartTransaction throws a transient MongoException (e.g. network glitch, server step-down), it's caught by the outer handler that sets CurrentSessionRef.Value = null and returns a no-session scope, but the session allocated is never disposed of. This PR fixes this by disposing of the session explicitly in the outer catch. 